### PR TITLE
PYTHONPATH set

### DIFF
--- a/codes/cogs/dices.py
+++ b/codes/cogs/dices.py
@@ -1,7 +1,7 @@
-import os, discord, random, time
+import sys, os, discord, random, time
 from discord.ext import commands
 
-import settings as st #Get the globals from Settings
+import codes.settings as st #Get the globals from Settings
 
 class Dices(commands.Cog):
     def __init__(self, bot):

--- a/codes/cogs/help.py
+++ b/codes/cogs/help.py
@@ -2,7 +2,7 @@ import os, discord, codecs, time
 from discord.ext import commands
 from discord import Colour
 
-import settings as st #Get the globals from Settings
+import codes.settings as st #Get the globals from Settings
 
 class Help(commands.Cog):
     def __init__(self, bot):

--- a/codes/cogs/management.py
+++ b/codes/cogs/management.py
@@ -7,7 +7,7 @@ from discord.ext import commands
 from discord.ext.commands import has_permissions, MissingPermissions
 from discord.ext.commands import Bot, guild_only
 
-import settings as st #Get the globals from Settings
+import codes.settings as st #Get the globals from Settings
 
 #Extension Management
 class Management(commands.Cog):

--- a/codes/cogs/messages.py
+++ b/codes/cogs/messages.py
@@ -2,7 +2,7 @@ import os, discord
 from discord.ext import commands
 from discord.ext.commands import has_permissions, MissingPermissions
 
-import settings as st #Get the globals from Settings
+import codes.settings as st #Get the globals from Settings
 
 class Messages(commands.Cog):
     def __init__(self, bot):

--- a/codes/cogs/rules.py
+++ b/codes/cogs/rules.py
@@ -1,7 +1,7 @@
 import os, discord, codecs
 from discord.ext import commands
 
-import settings as st #Get the globals from Settings
+import codes.settings as st #Get the globals from Settings
 
 class Rules(commands.Cog):
     def __init__(self, bot):

--- a/codes/cogs/stickers.py
+++ b/codes/cogs/stickers.py
@@ -1,11 +1,7 @@
 import os, discord
 from discord.ext import commands
 
-import settings as st #Get the globals from Settings
-
-#GLOBAL
-#Path no qual estão armazenados os stickerss
-image_path = './stickers/'
+import codes.settings as st #Get the globals from Settings
 
 class Stickers(commands.Cog):
     def __init__(self, bot):

--- a/codes/main.py
+++ b/codes/main.py
@@ -7,7 +7,8 @@ from dotenv import load_dotenv
 from discord.ext import commands
 from discord import Member
 
-import settings as st #Get the globals from Settings
+sys.path.append("D:\\python-codes\\Discordzada") #Config the PYTHONPATH to import "codes.settings" without warnings
+import codes.settings as st #Get the globals from Settings
 
 logging.basicConfig(level=logging.INFO)
 clear = lambda: os.system('cls')


### PR DESCRIPTION
Added PYTHONPATH config via sys.path.append() on main, to correctly import "codes.settings" in main.py and cogs without warnings